### PR TITLE
Fix JCursor printing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "purescript-profunctor-lenses": "^2.0.0"
   },
   "devDependencies": {
-    "purescript-strongcheck": "^2.0.0"
+    "purescript-strongcheck": "^2.0.0",
+    "purescript-strongcheck-laws": "^1.0.0"
   }
 }

--- a/src/Data/Argonaut/JCursor.purs
+++ b/src/Data/Argonaut/JCursor.purs
@@ -25,9 +25,9 @@ derive instance eqJCursor :: Eq JCursor
 derive instance ordJCursor :: Ord JCursor
 
 instance showJCursor :: Show JCursor where
-  show JCursorTop = ""
-  show (JField i c) = "." <> i <> show c
-  show (JIndex i c) = "[" <> show i <> "]" <> show c
+  show JCursorTop = "JCursorTop"
+  show (JField i c) = "(JField " <> show i <> " " <> show c <> ")"
+  show (JIndex i c) = "(JIndex " <> show i <> " " <> show c <> ")"
 
 instance semigroupJCursor :: Semigroup JCursor where
   append a JCursorTop = a
@@ -43,6 +43,14 @@ instance encodeJsonJCursor :: EncodeJson JCursor where
     loop JCursorTop = []
     loop (JField i c) = [encodeJson i] <> loop c
     loop (JIndex i c) = [encodeJson i] <> loop c
+
+-- | Accepts a name for the value the cursor is reading from, a cursor, and
+-- | prints a path like `value.field.field[index]`.
+printJCursor :: String -> JCursor -> String
+printJCursor valueName = case _ of
+  JCursorTop -> valueName
+  JField i c -> printJCursor valueName c <> "." <> i
+  JIndex i c -> printJCursor valueName c <> "[" <> show i <> "]"
 
 newtype JsonPrim = JsonPrim (forall a. (J.JNull -> a) -> (J.JBoolean -> a) -> (J.JNumber -> a) -> (J.JString -> a) -> a)
 

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -8,15 +8,23 @@ import Data.Argonaut.Decode (decodeJson)
 import Data.Argonaut.Encode (encodeJson)
 import Data.Argonaut.JCursor (JCursor(..))
 import Data.Either (Either(..))
+import Data.Monoid (class Monoid)
 
 import Test.StrongCheck (SC, Result, quickCheck', (<?>))
 import Test.StrongCheck.Arbitrary (class Arbitrary, arbitrary)
 import Test.StrongCheck.Gen (chooseInt)
+import Test.StrongCheck.Laws.Data as Data
+import Type.Proxy (Proxy(..))
 
 newtype TestJCursor = TestJCursor JCursor
 
 runTestJCursor :: TestJCursor -> JCursor
 runTestJCursor (TestJCursor cursor) = cursor
+
+derive newtype instance eqTestJCursor :: Eq TestJCursor
+derive newtype instance ordTestJCursor :: Ord TestJCursor
+derive newtype instance semigroupTestJCursor :: Semigroup TestJCursor
+derive newtype instance monoidTestJCursor :: Monoid TestJCursor
 
 instance arbJCursor :: Arbitrary TestJCursor where
   arbitrary = do
@@ -34,3 +42,12 @@ main :: SC () Unit
 main = do
   log "Testing JCursor serialization"
   quickCheck' 20 prop_jcursor_serialization
+
+  log "Testing laws for JCursor"
+  Data.checkEq prxJCursor
+  Data.checkOrd prxJCursor
+  Data.checkSemigroup prxJCursor
+  Data.checkMonoid prxJCursor
+
+  where
+  prxJCursor = Proxy :: Proxy TestJCursor


### PR DESCRIPTION
The `Show` instance was pretty-printing rather than showing the PS code for the `JCursor`, and also it was printing complete nonsense! (The order of accessors was reversed)

Added some law tests while I was at it.