### PR TITLE
Update for PureScript 0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,10 +21,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "purescript-argonaut-codecs": "^2.0.0",
-    "purescript-profunctor-lenses": "^2.0.0"
+    "purescript-argonaut-codecs": "^3.0.0",
+    "purescript-profunctor-lenses": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-strongcheck": "^2.0.0"
+    "purescript-strongcheck": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   },
   "devDependencies": {
     "eslint": "^3.10.2",
-    "pulp": "^10.0.0",
-    "purescript-psa": "^0.3.9",
-    "purescript": "^0.10.2",
+    "pulp": "^11.0.0",
+    "purescript-psa": "^0.5.0",
+    "purescript": "^0.11.0",
     "rimraf": "^2.5.4"
   }
 }

--- a/src/Data/Argonaut/JCursor.purs
+++ b/src/Data/Argonaut/JCursor.purs
@@ -150,7 +150,7 @@ toPrims = J.foldJson nullFn boolFn numFn strFn arrFn objFn
   objFn obj =
     let f :: Tuple String J.Json -> List (Tuple JCursor JsonPrim)
         f (Tuple i j) = (\t -> Tuple (JField i (fst t)) (snd t)) <$> toPrims j
-    in M.toList obj >>= f
+    in M.toUnfoldable obj >>= f
 
 fromPrims :: List (Tuple JCursor JsonPrim) -> Maybe J.Json
 fromPrims lst = foldl f (inferEmpty <<< fst <$> head lst) lst


### PR DESCRIPTION
Bumped dependencies and changed `toList` to `toUnfoldable`. No other changes required.