### PR TITLE
Update README with more general Argonaut information

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,28 @@
 [![Maintainer: garyb](https://img.shields.io/badge/maintainer-garyb-lightgrey.svg)](http://github.com/garyb)
 [![Maintainer: thomashoneyman](https://img.shields.io/badge/maintainer-thomashoneyman-lightgrey.svg)](http://github.com/thomashoneyman)
 
-Prisms, traversals, and zipper for the Argonaut `Json` type.
+[Argonaut](https://github.com/purescript-contrib/purescript-argonaut) is a collection of libraries for working with JSON in PureScript. `argonaut-traversals` defines prisms, traversals, and zipper for the Argonaut `Json` type.
 
 ## Installation
 
-```
+This library is bundled as part of [Argonaut](https://github.com/purescript-contrib/purescript-argonaut) and can be installed via that library. To install just `argonaut-traversals`:
+
+```sh
+# with Spago
+spago install argonaut-traversals
+
+# with Bower
 bower install purescript-argonaut-traversals
 ```
 
 ## Documentation
 
-Module documentation is [published on Pursuit](http://pursuit.purescript.org/packages/purescript-argonaut-traversals).
+Module documentation is [published on Pursuit](https://pursuit.purescript.org/packages/purescript-argonaut-traversals). You may also be interested in other libraries in the Argonaut ecosystem:
+
+- [purescript-argonaut-core](https://github.com/purescript-contrib/purescript-argonaut-core) defines the `Json` type, along with basic parsing, printing, and folding functions
+- [purescript-argonaut-codecs](https://github.com/purescript-contrib/purescript-argonaut-codecs) provides codecs based on `EncodeJson` and `DecodeJson` type classes, along with instances for common data types and combinators for encoding and decoding `Json` values.
+- [purescript-codec-argonaut](https://github.com/garyb/purescript-codec-argonaut) supports an alternative approach for codecs, which are based on profunctors instead of type classes.
+- [purescript-argonaut-generic](https://github.com/purescript-contrib/purescript-argonaut-generic) supports generic encoding and decoding for any type with a `Generic` instance.
 
 ## Contributing
 


### PR DESCRIPTION
## What does this pull request do?

This PR updates this repository's documentation with information about the Argonaut ecosystem.

I think each of the Argonaut repositories ought to contain some brief summary information about using them together. Users can then choose whether to install just the library in question or to install the main argonaut package, and have easy access to read about each of the libraries in the ecosystem.

It seems like a harmless addition to the README which could carry some significant benefits in discoverability.