### PR TITLE
Add in direct dependencies needed to pass CI checks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,21 @@
   "dependencies": {
     "purescript-argonaut-codecs": "^8.0.0",
     "purescript-argonaut-core": "^6.0.0",
-    "purescript-profunctor-lenses": "^7.0.0"
+    "purescript-arrays": "^6.0.0",
+    "purescript-control": "^5.0.0",
+    "purescript-either": "^5.0.0",
+    "purescript-foldable-traversable": "^5.0.0",
+    "purescript-foreign-object": "^3.0.0",
+    "purescript-gen": "^3.0.0",
+    "purescript-integers": "^5.0.0",
+    "purescript-lists": "^6.0.0",
+    "purescript-maybe": "^5.0.0",
+    "purescript-prelude": "^5.0.0",
+    "purescript-profunctor-lenses": "^7.0.0",
+    "purescript-strings": "^5.0.0",
+    "purescript-tailrec": "^5.0.0",
+    "purescript-tuples": "^6.0.0",
+    "purescript-unfoldable": "^5.0.0"
   },
   "devDependencies": {
     "purescript-console": "^5.0.0",

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,11 +2,25 @@
 , dependencies =
   [ "argonaut-codecs"
   , "argonaut-core"
+  , "arrays"
   , "console"
+  , "control"
   , "effect"
+  , "either"
+  , "foldable-traversable"
+  , "foreign-object"
+  , "gen"
+  , "integers"
+  , "lists"
+  , "maybe"
+  , "prelude"
   , "profunctor-lenses"
   , "psci-support"
   , "quickcheck"
+  , "strings"
+  , "tailrec"
+  , "tuples"
+  , "unfoldable"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]


### PR DESCRIPTION
**Description of the change**
Adds any needed direct dependencies for passing the GitHub checks to spago.dhall and bower.json (see [purescript-contrib/governance#43](https://github.com/purescript-contrib/governance/issues/43)).
---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
